### PR TITLE
Refactor: interaction between elements

### DIFF
--- a/server/index.lua
+++ b/server/index.lua
@@ -18,46 +18,40 @@ local function playerConnectingHandler(name, setKickReason, deferrals)
 
     local card = Card:new()
 
-    local columnSet = CardColumnSet:new(
-        {
-            alignement = {
-                horizontal = "Left"
-            }
-        },
-        CardColumn:new({},
-            CardElement.Image({
-                url = 'https://placehold.co/69',
-                alignment = 'Center',
-                size = 'medium',
-            })
-        ),
-        CardColumn:new({},
-            CardElement.TextBlock({
-                text = ('Hello, %s (%d)!'):format(name, tonumber(src)),
-                style = 'heading',
-            })
-        )
-    )
-
-    local container = CardContainer:new({
-        alignement = {
-            horizontal = 'Center',
-            vertical = 'Center'
-        },
-        spacing = 'Large',
-    },
-        columnSet:getComponent()
-    )
-
-    local textInput = CardInput:new('text', {
-        id = 'text_input',
-        label = 'Provide a nice label',
-        placeholder = 'This is dum',
-    })
-
     card:addElement(
-        container:getComponent(),
-        textInput:getComponent(),
+        CardContainer:new({
+            alignement = {
+                horizontal = 'Center',
+                vertical = 'Center'
+            },
+            spacing = 'Large',
+        },
+            CardColumnSet:new(
+                {
+                    alignement = {
+                        horizontal = "Left"
+                    }
+                },
+                CardColumn:new({},
+                    CardElement.Image({
+                        url = 'https://placehold.co/69',
+                        alignment = 'Center',
+                        size = 'medium',
+                    })
+                ),
+                CardColumn:new({},
+                    CardElement.TextBlock({
+                        text = ('Hello, %s (%d)!'):format(name, tonumber(src)),
+                        style = 'heading',
+                    })
+                )
+            )
+        ),
+        CardInput:new('text', {
+            id = 'text_input',
+            label = 'Provide a nice label',
+            placeholder = 'This is dum',
+        }),
         CardElement.Media({
             poster = 'https://placehold.co/69',
             sources = {
@@ -67,22 +61,18 @@ local function playerConnectingHandler(name, setKickReason, deferrals)
         })
     )
 
-    local openUrl = CardAction:new({
-        id = 'open_url',
-        title = 'Open rules',
-        type = 'url',
-        url = 'https://github.com/Maximus7474/mps-adaptivecards'
-    })
-
-    local action = CardAction:new({
-        id = 'submitbutton',
-        title = 'Submit Button',
-        type = 'submit'
-    })
-
     card:addAction(
-        action:getComponent(),
-        openUrl:getComponent()
+        CardAction:new({
+            id = 'open_url',
+            title = 'Open rules',
+            type = 'url',
+            url = 'https://github.com/Maximus7474/mps-adaptivecards'
+        }),
+        CardAction:new({
+            id = 'submitbutton',
+            title = 'Submit Button',
+            type = 'submit'
+        })
     )
 
     deferrals.presentCard(card:toJson(), function (data, rawData)

--- a/server/lib/cardColumnSet.lua
+++ b/server/lib/cardColumnSet.lua
@@ -144,6 +144,25 @@ function CardColumnSet:new(data, ...)
     return columnSetInstance
 end
 
+---add a column to the set 
+---@param ... CardColumn
+function CardColumnSet:addColumn(...)
+    local elements = { ... }
+    for i = 1, #elements, 1 do
+        local element = elements[i]
+
+        if getmetatable(element) == CardColumn then
+            goto valid
+        end
+
+        error('Invalid element passed through "CardColumnSet:new", it has to be CardColumn', 2)
+
+        ::valid::
+
+        table.insert(self.columnSetData.items, element:getComponent())
+    end
+end
+
 function CardColumnSet:getComponent()
     return self.columnSetData
 end

--- a/server/lib/cardColumnSet.lua
+++ b/server/lib/cardColumnSet.lua
@@ -20,6 +20,8 @@ local validColumnElements = {
     CardElement, CardInput
 }
 
+---create a new column
+---@param ... CardElement | CardInput
 function CardColumn:new(data, ...)
     if not data then data = {} end
 

--- a/server/lib/cardColumnSet.lua
+++ b/server/lib/cardColumnSet.lua
@@ -2,6 +2,7 @@ local CardElement = require 'server.lib.cardElement'
 local CardInput = require 'server.lib.cardInput'
 
 ---@class CardColumn: CardContainer
+---@field columnData table
 local CardColumn = {}
 CardColumn.__index = CardColumn
 

--- a/server/lib/cardColumnSet.lua
+++ b/server/lib/cardColumnSet.lua
@@ -65,6 +65,30 @@ function CardColumn:new(data, ...)
     return columnInstance
 end
 
+---add an element to the column
+---@param ... CardElement | CardInput
+function CardColumn:addElements(...)
+    local elements = { ... }
+    for i = 1, #elements, 1 do
+        local element = elements[i]
+
+        local metatable = getmetatable(element)
+        for idx = 1, #validColumnElements do
+            local metatableElement = validColumnElements[idx]
+
+            if metatable == metatableElement then
+                goto valid
+            end
+        end
+
+        error('Invalid element passed through "CardColumn:new", it has to be on of: CardElement, CardInput, CardContainer', 2)
+
+        ::valid::
+
+        table.insert(self.columnData.items, element:getComponent())
+    end
+end
+
 function CardColumn:getComponent()
     return self.columnData
 end

--- a/server/lib/cardElement.lua
+++ b/server/lib/cardElement.lua
@@ -1,4 +1,9 @@
 local CardElement = {}
+CardElement.__index = CardElement
+
+---@class AdaptiveCardElement: table<string, boolean | string | number | table>
+---@field type string
+---@field getComponent fun(): table
 
 ---@class TextBlockOptions
 ---@field text string
@@ -8,26 +13,9 @@ local CardElement = {}
 ---@field style? 'default' | 'heading' | 'code' | 'list'
 ---@field fontType? 'default' | 'monospace'
 ---@field isSubtle? boolean
-
---- Create a text block
----@param data TextBlockOptions
-function CardElement.TextBlock(data)
-    if type(data.text) ~= "string" then
-        error(('Invalid "text" value (found %s instead of string) passed in TextBlock'):format(type(data.text)), 2)
-    end
-
-    return {
-        type = "TextBlock",
-        text = data.text,
-
-        size = data.size or nil,
-        weight = data.weight or nil,
-        color = data.color or nil,
-        style = data.style or nil,
-        fontType = data.fontType or nil,
-        isSubtle = data.isSubtle or false,
-    }
-end
+---@field wrap? boolean
+---@field maxLines? number
+---@field horizontalAlignment? 'Left' | 'Center' | 'Right'
 
 ---@class ImageOptions
 ---@field url string
@@ -35,25 +23,6 @@ end
 ---@field style? 'default' | 'person'
 ---@field size? 'auto' | 'stretch' | 'small' | 'medium' | 'large'
 ---@field alignment? 'Left' | 'Center' | 'Right'
-
---- Create an image block
----@param data ImageOptions
-function CardElement.Image(data)
-
-    if type(data.url) ~= "string" then
-        error(('Invalid "url" value (found %s instead of string) passed in Image'):format(type(data.url)), 2)
-    end
-
-    return {
-        type = "Image",
-        url = data.url,
-
-        altText = data.altText or nil,
-        style = data.style or nil,
-        size = data.size or nil,
-        horizontalAlignment = data.alignment or nil,
-    }
-end
 
 ---@class MediaSource
 ---@field mimeType 'video/mp4' | 'video/webm' | 'audio/mpeg' | 'audio/mp3'
@@ -64,10 +33,85 @@ end
 ---@field sources table<integer, MediaSource> | MediaSource
 ---@field altText? string
 
----Add media elements
----@param data MediaOptions
-function CardElement.Media(data)
+---@param cardType string The type of the element.
+---@param data table The properties of the element.
+---@return CardElement
+function CardElement:new(cardType, data)
+    if type(cardType) ~= 'string' then
+        error("CardElement:new requires a 'type' string.", 2)
+    end
 
+    if not data then data = {} end
+
+    local cardElementData = {
+        type = cardType
+    }
+
+    -- Merge properties from the data table
+    for key, value in pairs(data) do
+        if value ~= nil then
+            cardElementData[key] = value
+        end
+    end
+
+    local cardElementInstance = {
+        cardElementData = cardElementData
+    }
+
+    setmetatable(cardElementInstance, self)
+
+    return cardElementInstance
+end
+
+---@return table
+function CardElement:getComponent()
+    return self.cardElementData
+end
+
+---@param data TextBlockOptions
+---@return CardElement
+function CardElement.TextBlock(data)
+    if type(data.text) ~= "string" then
+        error(('Invalid "text" value (found %s instead of string) passed in TextBlock'):format(type(data.text)), 2)
+    end
+
+    local props = {
+        text = data.text,
+        size = data.size,
+        weight = data.weight,
+        color = data.color,
+        style = data.style,
+        fontType = data.fontType,
+        isSubtle = data.isSubtle or false,
+        wrap = data.wrap,
+        maxLines = data.maxLines,
+        horizontalAlignment = data.horizontalAlignment,
+    }
+
+    return CardElement:new("TextBlock", props)
+end
+
+---@param data ImageOptions
+---@return CardElement
+function CardElement.Image(data)
+    if type(data.url) ~= "string" then
+        error(('Invalid "url" value (found %s instead of string) passed in Image'):format(type(data.url)), 2)
+    end
+
+    local props = {
+        url = data.url,
+        altText = data.altText,
+        style = data.style,
+        size = data.size,
+        horizontalAlignment = data.alignment,
+    }
+
+    return CardElement:new("Image", props)
+end
+
+---@param data MediaOptions
+---@return CardElement
+function CardElement.Media(data)
     if type(data.poster) ~= 'string' then
         error(('Invalid "poster" value (found %s instead of string) passed in Media'):format(type(data.poster)), 2)
     end
@@ -77,6 +121,7 @@ function CardElement.Media(data)
     end
 
     local sources = {}
+
     if type(data.sources.url) == 'string' then
         table.insert(sources, data.sources)
     elseif #data.sources > 0 then
@@ -84,21 +129,16 @@ function CardElement.Media(data)
     end
 
     if #sources == 0 then
-        error(('Invalid "sources" value (requires a non empty table) passed in Media'):format(type(data.sources)), 2)
+        error('Invalid "sources" value (requires a non-empty table) passed in Media', 2)
     end
 
-    return {
-        type = 'Media',
+    local props = {
         poster = data.poster,
         sources = sources,
-
-        altText = data.altText or nil,
+        altText = data.altText,
     }
-end
 
----@class CardElement
----@field TextBlock fun(data: TextBlockOptions): table create a text block
----@field Image fun(data: ImageOptions): table create an image
----@field Media fun(data: MediaOptions): table create a media element
+    return CardElement:new("Media", props)
+end
 
 return CardElement


### PR DESCRIPTION
## Description

Main change brought within this PR is an easier construction flow for adaptive cards with a more discord.js like builder concept.
Instead of having to save the returned metatable and call `:getComponent()` on it now you just need to pass the metatable as a parameter.

## Major Changes

- Major refactor on components accepting other components as children
  - Card, CardColumnSet, CardColumn, CardContainer
- Better validation for passed children

## Modifications done
- [ ] 🍃 New Feature
- [x] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
